### PR TITLE
Show latest products in the order they were last added.

### DIFF
--- a/app/views/spree/home/index.html.erb
+++ b/app/views/spree/home/index.html.erb
@@ -30,7 +30,7 @@
       <h3>Latest Products</h3>
       <hr>
       <ul class="carousel">
-        <% @latest_products.each do |product| %>
+        <% @latest_products.sort_by{ |product| product.created_at }.reverse.each do |product| %>
           <%= render 'product', :product => product %>
         <% end %>
       </ul>


### PR DESCRIPTION
I think it would make sense if we actually show latest products on the home page in the order they were last added, rather than pushing recently added ones to the very end of the list, which is counter-intuitive. 

Please review this change.

Thanks :)
