### PR TITLE
Fix payment method selection in checkout

### DIFF
--- a/app/overrides/spree/checkout/_payment/make_paymeth_method_selection_as_a_button.html.erb.deface
+++ b/app/overrides/spree/checkout/_payment/make_paymeth_method_selection_as_a_button.html.erb.deface
@@ -2,7 +2,7 @@
 <!-- closing_selector 'code:contains("end")' -->
 <div class="payment-method-selector">
   <% @order.available_payment_methods.each do |method| %>    
-    <%= radio_button_tag "order[payments_attributes][][payment_method_id]", method.id, method == @order.payment_method %>
+    <%= radio_button_tag "order[payments_attributes][][payment_method_id]", method.id %>
     <label for="order_payments_attributes__payment_method_id_<%= method.id %>">
       <%= t(method.name, :scope => :payment_methods, :default => method.name) %>
     </label>


### PR DESCRIPTION
payment_method was removed from order model in spree/spree@6634692138f3ecc26af67e27288fba009ea2dde8
