### PR TITLE
Fix for checkout payment view, @order.payment_method no longer exists

### DIFF
--- a/app/overrides/spree/checkout/_payment/make_paymeth_method_selection_as_a_button.html.erb.deface
+++ b/app/overrides/spree/checkout/_payment/make_paymeth_method_selection_as_a_button.html.erb.deface
@@ -2,7 +2,7 @@
 <!-- closing_selector 'code:contains("end")' -->
 <div class="payment-method-selector">
   <% @order.available_payment_methods.each do |method| %>    
-    <%= radio_button_tag "order[payments_attributes][][payment_method_id]", method.id, method == @order.payment_method %>
+    <%= radio_button_tag "order[payments_attributes][][payment_method_id]", method.id, method == @order.available_payment_methods.last %>
     <label for="order_payments_attributes__payment_method_id_<%= method.id %>">
       <%= t(method.name, :scope => :payment_methods, :default => method.name) %>
     </label>


### PR DESCRIPTION
The order payment_method method no longer exists in the spree 1-3-stable branch, this commit modifies the override for the checkout/_payment.html.erb partial to use the last available_payment_methods instance instead.
