### PR TITLE
Fix producst list styling

### DIFF
--- a/app/assets/stylesheets/store/shared/_layout.scss
+++ b/app/assets/stylesheets/store/shared/_layout.scss
@@ -114,6 +114,10 @@ body {
   margin-bottom: 30px;
 }
 
+ul#products {
+  max-width: 600px;
+}
+
 ul#products li {
   margin-bottom: 20px;
 

--- a/app/overrides/spree/shared/_products/group_products_list_by_3_in_row.html.erb.deface
+++ b/app/overrides/spree/shared/_products/group_products_list_by_3_in_row.html.erb.deface
@@ -4,7 +4,7 @@
     <li class="product-row">
       <ul>
         <% product_row.each do |product| %>
-          <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", :name => "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
+          <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "omega secondary", :name => "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
             <div class="product-image">
               <%= link_to small_image(product, :itemprop => "image"), product, :itemprop => 'url' %>
             </div>


### PR DESCRIPTION
The list was cycling through 4 products when they were only grouped in 3

[Fixes #37]

@devilcoders It fixes the issue as far as I can see. But I'd appreciate you feedback on it just to make sure it won't break anything else.
