### PR TITLE
Fix exception being thrown if a product description is empty

### DIFF
--- a/app/views/spree/home/_slider.html.erb
+++ b/app/views/spree/home/_slider.html.erb
@@ -9,7 +9,7 @@
           <div class="product-info">
             <h1 class="product-title"><%= product.name %> - <%= product.sku %></h1>
             <div class="product-description">
-              <%= product.description.html_safe if product.description %>
+              <%= product.description.to_s.html_safe %>
             </div>
             <div class="product-order-form">
               <%= form_for :order, :url => populate_orders_path do |f| %>


### PR DESCRIPTION
Easily fixed by calling .html_safe on description only if a description exists.
