### PR TITLE
fix dependencies for spree 2-0-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree'
+gem 'spree', github: 'spree/spree', branch: "2-0-stable"
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: "spree/spree_auth_devise"
+gem 'spree_auth_devise', github: "spree/spree_auth_devise", branch: "2-0-stable"
 
 gemspec

--- a/spree_fancy.gemspec
+++ b/spree_fancy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', '~> 2.0.0'
   s.add_dependency 'compass-rails'
   s.add_dependency 'jquery-ui-rails'
-  s.add_dependency 'deface', '~> 1.0.0rc3'
+  #s.add_dependency 'deface', '~> 1.0.0rc3'
 
   s.add_development_dependency 'capybara', '1.0.1'
   s.add_development_dependency 'factory_girl', '~> 2.6.4'


### PR DESCRIPTION
spree_fancy 2-0-stable should be working on spree 2-0-stable. This PR will fix that.
