### PR TITLE
Update hide_tags_taxonomy.html.erb.deface

### DIFF
--- a/app/overrides/spree/shared/_taxonomies/hide_tags_taxonomy.html.erb.deface
+++ b/app/overrides/spree/shared/_taxonomies/hide_tags_taxonomy.html.erb.deface
@@ -1,6 +1,6 @@
 <!-- replace_contents '#taxonomies' -->
 
-<% get_taxonomies.each do |taxonomy| %>
+<% @taxonomies.each do |taxonomy| %>
   <% unless taxonomy.name == 'Tags' %>
     <h6 class='taxonomy-root'><%= Spree.t(:shop_by_taxonomy, :taxonomy => taxonomy.name) %></h6>
     <%= taxons_tree(taxonomy.root, @taxon, Spree::Config[:max_level_in_taxons_menu] || 1) %>


### PR DESCRIPTION
fixes issue #95
Spree 2.2 no longer has "get_taxonomies"
https://github.com/spree/spree_fancy/issues/95

@radar
