### PR TITLE
Remove references to :show_zero_stock_products and :allow_backorders. 

### DIFF
--- a/app/overrides/spree/products/_cart_form/replace_varaints_selection_markup_to_fit_for_jquery_ui.html.erb.deface
+++ b/app/overrides/spree/products/_cart_form/replace_varaints_selection_markup_to_fit_for_jquery_ui.html.erb.deface
@@ -2,11 +2,11 @@
 <div class="variants-buttons">
   <% has_checked = false
   @product.variants.active(current_currency).each_with_index do |v,index|
-    next if v.option_values.empty? || (!v.in_stock? && !Spree::Config[:show_zero_stock_products])
-    checked = !has_checked && (v.in_stock? || Spree::Config[:allow_backorders])
+    next if v.option_values.empty?
+    checked = !has_checked && (v.can_supply?)
     has_checked = true if checked %>
     
-      <%= radio_button_tag "products[#{@product.id}]", v.id, checked, :disabled => !v.in_stock? && !Spree::Config[:allow_backorders], 'data-price' => v.price_in(current_currency).display_price %>
+      <%= radio_button_tag "products[#{@product.id}]", v.id, checked, :disabled => !v.can_supply?, 'data-price' => v.price_in(current_currency).display_price %>
       <label for="<%= ['products', @product.id, v.id].join('_') %>">
         <span class="variant-description">
           <%= variant_options v %>


### PR DESCRIPTION
Instead use can_supply to determine which variants to grey out. Fixes #93
