### PR TITLE
Set parent_id when creating Slider, Featured, and Latest

### DIFF
--- a/db/migrate/20121211151950_add_slider_taxons_and_apply_them.rb
+++ b/db/migrate/20121211151950_add_slider_taxons_and_apply_them.rb
@@ -1,9 +1,9 @@
 class AddSliderTaxonsAndApplyThem < ActiveRecord::Migration
   def up
     tags      = Spree::Taxonomy.create(:name => 'Tags')
-    slider    = Spree::Taxon.create({:taxonomy_id => tags.id, :name => 'Slider'})
-    featured  = Spree::Taxon.create({:taxonomy_id => tags.id, :name => 'Featured'})
-    latest    = Spree::Taxon.create({:taxonomy_id => tags.id, :name => 'Latest'})
+    slider    = Spree::Taxon.create({:taxonomy_id => tags.id, :parent_id => tags.root.id, :name => 'Slider'})
+    featured  = Spree::Taxon.create({:taxonomy_id => tags.id, :parent_id => tags.root.id, :name => 'Featured'})
+    latest    = Spree::Taxon.create({:taxonomy_id => tags.id, :parent_id => tags.root.id, :name => 'Latest'})
 
     products = Spree::Product.all
     


### PR DESCRIPTION
Fixes spree_fancy taxons not appearing in admin, or being destroyed when rolling back the spree_fancy migration. Should work on all branches.
