### PR TITLE
Fix rolling back migration after Tags taxonomy was accidentally deleted or duplicated

### DIFF
--- a/db/migrate/20121211151950_add_slider_taxons_and_apply_them.rb
+++ b/db/migrate/20121211151950_add_slider_taxons_and_apply_them.rb
@@ -25,6 +25,6 @@ class AddSliderTaxonsAndApplyThem < ActiveRecord::Migration
   end
 
   def down
-    Spree::Taxonomy.where(:name => 'Tags').first.destroy()
+    Spree::Taxonomy.where(:name => 'Tags').destroy_all
   end
 end


### PR DESCRIPTION
Make it easier to re-run spree_fancy migration if the Tags taxonomy has been accidentally duplicated or destroyed.
