### PR TITLE
beautify the user-info section in order to let extention feels easy

### DIFF
--- a/app/assets/stylesheets/spree/fancy/sections/_user.scss
+++ b/app/assets/stylesheets/spree/fancy/sections/_user.scss
@@ -13,7 +13,13 @@
   }
 
   dd {
+    display: inline;
     margin-left: inherit;  
+  }
+
+  dd:after {
+    content: '\A';
+    white-space: pre;
   }
   
 }


### PR DESCRIPTION
I use [spree_reffiliate](https://github.com/kinduff/spree_reffiliate) extension and get the following UI:
![screen shot 2015-03-19 at 21 31 59](https://cloud.githubusercontent.com/assets/2620575/6731582/bdb80d7e-ce80-11e4-8c5a-dc7ee1e0c43f.png)

So I think the spree_fancy theme should be more extendable in the `user-info` section, I follow the html structure and just do a little bit css modifications base on [this solution](http://stackoverflow.com/questions/4609279/css-to-line-break-before-after-a-particular-inline-block-item).
Everything looks perfect now like this:

![screen shot 2015-03-19 at 21 30 57](https://cloud.githubusercontent.com/assets/2620575/6731588/c2ea5b08-ce80-11e4-808a-07bc6450ff4b.png)

I use 2-3-stable version, and can be applied to all stable version I think.
